### PR TITLE
Feat/#3 - Make Post registration, delection, retrieval, edit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+
+    implementation 'mysql:mysql-connector-java'
     // AWS S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/com/sparta/sixhundredbills/SixhundredBillsApplication.java
+++ b/src/main/java/com/sparta/sixhundredbills/SixhundredBillsApplication.java
@@ -1,0 +1,16 @@
+package com.sparta.sixhundredbills;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+public class SixhundredBillsApplication{
+
+    public static void main(String[] args) {
+        SpringApplication.run(SixhundredBillsApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/sparta/sixhundredbills/auth/entity/Role.java
+++ b/src/main/java/com/sparta/sixhundredbills/auth/entity/Role.java
@@ -1,0 +1,6 @@
+package com.sparta.sixhundredbills.auth.entity;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/sparta/sixhundredbills/auth/entity/User.java
+++ b/src/main/java/com/sparta/sixhundredbills/auth/entity/User.java
@@ -1,0 +1,29 @@
+package com.sparta.sixhundredbills.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+// DB 테이블에 매핑되는 Entity
+// => 사용자의 정보를 저장하는 역할.
+
+@Entity
+@Getter
+@Setter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+}

--- a/src/main/java/com/sparta/sixhundredbills/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/sixhundredbills/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.sparta.sixhundredbills.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.io.IOException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 유효하지 않은 토큰
+     * @param message
+     * @return : 401 에러와 오류 메시지 반환
+     */
+    // 유효하지 않은 토큰
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<String> handleInvalidTokenException(String message) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
+
+    }
+
+    /**
+     * InfoNotCorrectedException: 유저정보가 맞지 않을때
+     * @param message
+     * @return
+     */
+    @ExceptionHandler(InfoNotCorrectedException.class)
+    public ResponseEntity<String> InfoNotCorrectedException(String message) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).contentType(MediaType.APPLICATION_JSON).body(message);
+    }
+
+    /**
+     * 해당 게시물이 DB에 존재하지 않을 때
+     *
+     * @return : 클라이언트로 에러 코드와 메시지 반환
+     */
+    @ExceptionHandler(NotFoundPostException.class)
+    public ResponseEntity<String> notFoundPostHandler() {
+        return ResponseEntity.status(400).body("해당 게시물은 존재하지 않습니다.");
+    }
+
+}

--- a/src/main/java/com/sparta/sixhundredbills/exception/InfoNotCorrectedException.java
+++ b/src/main/java/com/sparta/sixhundredbills/exception/InfoNotCorrectedException.java
@@ -1,0 +1,7 @@
+package com.sparta.sixhundredbills.exception;
+
+public class InfoNotCorrectedException extends RuntimeException {
+    public InfoNotCorrectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/sixhundredbills/exception/NotFoundPostException.java
+++ b/src/main/java/com/sparta/sixhundredbills/exception/NotFoundPostException.java
@@ -1,0 +1,6 @@
+package com.sparta.sixhundredbills.exception;
+
+public class NotFoundPostException extends RuntimeException{
+    public NotFoundPostException() {
+    }
+}

--- a/src/main/java/com/sparta/sixhundredbills/exception/UnauthorizedException.java
+++ b/src/main/java/com/sparta/sixhundredbills/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.sparta.sixhundredbills.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/sparta/sixhundredbills/post/controller/PostController.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/controller/PostController.java
@@ -1,11 +1,71 @@
 package com.sparta.sixhundredbills.post.controller;
 
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.sparta.sixhundredbills.auth.entity.User;
+import com.sparta.sixhundredbills.post.dto.PostRequestDto;
+import com.sparta.sixhundredbills.post.dto.PostResponseDto;
+import com.sparta.sixhundredbills.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/post")
+@RequiredArgsConstructor
 public class PostController {
 
+    private final PostService postService;
+
+    /**
+     * 게시물을 생성하는 메서드
+     * @param postRequestDto 게시물 생성 요청 DTO
+     * @param user 인증된 사용자 정보
+     * @return 생성된 게시물 정보
+     */
+    @PostMapping
+    public ResponseEntity<PostResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal User user) {
+        PostResponseDto responseDto = postService.createPost(postRequestDto, user);
+        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+
+    /**
+     * 모든 게시물을 페이지네이션하여 조회하는 메서드
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return 페이지네이션된 게시물 목록
+     */
+    @GetMapping
+    public ResponseEntity<Page<PostResponseDto>> getPosts(@RequestParam int page, @RequestParam int size) {
+        Page<PostResponseDto> posts = postService.getPosts(page, size);
+        return new ResponseEntity<>(posts, HttpStatus.OK);
+    }
+
+    /**
+     * 게시물을 수정하는 메서드
+     * @param postId 수정할 게시물 ID
+     * @param postRequestDto 게시물 수정 요청 DTO
+     * @param user 인증된 사용자 정보
+     * @return 수정된 게시물 정보
+     */
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal User user) {
+        PostResponseDto responseDto = postService.updatePost(postId, postRequestDto, user);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    /**
+     * 게시물을 삭제하는 메서드
+     * @param postId 삭제할 게시물 ID
+     * @param user 인증된 사용자 정보
+     * @return 삭제 결과
+     */
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal User user) {
+        postService.deletePost(postId, user);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/dto/PostRequestDto.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/dto/PostRequestDto.java
@@ -1,4 +1,28 @@
 package com.sparta.sixhundredbills.post.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@Setter
 public class PostRequestDto {
+
+    @NotBlank(message = "내용이 비어있습니다.")
+    private String content; // 게시물 내용
+
+    private String showName; // 익명으로 표시될 이름
+
+    @NotBlank(message = "카테고리를 입력해주세요.")
+    private String category; // 게시물 카테고리
+
+    // 유효한 카테고리 목록
+    private static final List<String> VALID_CATEGORIES = Arrays.asList("일상공유", "고민상담");
+
+    // 카테고리 유효성 검사
+    public boolean isValidCategory() {
+        return VALID_CATEGORIES.contains(this.category);
+    }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/dto/PostResponseDto.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/dto/PostResponseDto.java
@@ -1,4 +1,41 @@
 package com.sparta.sixhundredbills.post.dto;
 
+import com.sparta.sixhundredbills.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
 public class PostResponseDto {
+    private Long id; // 게시물 ID
+    private Long userId; // 작성자 ID
+    private String showName; // 익명으로 표시될 이름
+    private String content; // 게시물 내용
+    private String category; // 게시물 카테고리
+    private LocalDateTime createdAt; // 생성일자
+    private LocalDateTime updatedAt; // 수정일자
+
+    // 모든 필드를 포함하는 생성자
+    @Builder
+    public PostResponseDto(Long id, Long userId, String showName, String content, String category, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.showName = showName;
+        this.content = content;
+        this.category = category;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Post 엔티티를 기반으로 PostResponseDto를 생성하는 생성자
+    public PostResponseDto(Post post) {
+        this.id = post.getId();
+        this.userId = post.getUser().getId();
+        this.showName = post.getShowName();
+        this.content = post.getContent();
+        this.category = post.getCategory();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getModifiedAt();
+    }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/entity/Post.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/entity/Post.java
@@ -1,4 +1,58 @@
 package com.sparta.sixhundredbills.post.entity;
 
-public class Post {
+import com.sparta.sixhundredbills.auth.entity.User;
+import com.sparta.sixhundredbills.timestamp.TimeStamp;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Post extends TimeStamp {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 게시물 ID
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 작성자
+
+    private String showName; // 익명으로 표시될 이름
+    private String content; // 게시물 내용
+    private String category; // 게시물 카테고리
+    private int likeCount; // 좋아요 수
+
+    @Builder
+    public Post(User user, String showName, String content, String category, int likeCount) {
+        this.user = user;
+        this.showName = showName;
+        this.content = content;
+        this.category = category;
+        this.likeCount = likeCount;
+    }
+
+    // 게시물 내용 수정
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    // 작성자 정보 수정
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    // 작성자 이름 수정
+    public void setShowName(String showName) {
+        this.showName = showName;
+    }
+
+    // 카테고리 수정
+    public void setCategory(String category) {
+        this.category = category;
+    }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/repository/PostRepository.java
@@ -1,4 +1,12 @@
 package com.sparta.sixhundredbills.post.repository;
 
-public interface PostRepository {
+import com.sparta.sixhundredbills.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Page<Post> findAll(Pageable pageable); // 모든 게시물을 페이지네이션하여 조회
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/service/PostService.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/service/PostService.java
@@ -1,4 +1,124 @@
 package com.sparta.sixhundredbills.post.service;
 
+import com.sparta.sixhundredbills.auth.entity.User;
+import com.sparta.sixhundredbills.exception.NotFoundPostException;
+import com.sparta.sixhundredbills.exception.UnauthorizedException;
+import com.sparta.sixhundredbills.post.dto.PostRequestDto;
+import com.sparta.sixhundredbills.post.dto.PostResponseDto;
+import com.sparta.sixhundredbills.post.entity.Post;
+import com.sparta.sixhundredbills.post.repository.PostRepository;
+import com.sparta.sixhundredbills.util.AnonymousNameGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
 public class PostService {
+
+    private final PostRepository postRepository;
+
+    /**
+     * 게시물을 생성하는 메서드
+     * @param postRequestDto 게시물 생성 요청 DTO
+     * @param user 작성자 정보
+     * @return 생성된 게시물 정보
+     */
+    public PostResponseDto createPost(PostRequestDto postRequestDto, User user) {
+        // 카테고리 유효성 검사
+        if (!postRequestDto.isValidCategory()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담 2개의 카테고리 중 하나를 입력해주세요.");
+        }
+
+        // 익명 닉네임 생성
+        String anonymousName = AnonymousNameGenerator.generate();
+
+        // Post 객체를 빌더 패턴을 사용하여 생성
+        Post post = Post.builder()
+                .user(user)
+                .showName(anonymousName) // 익명 닉네임 설정
+                .content(postRequestDto.getContent())
+                .category(postRequestDto.getCategory())
+                .likeCount(0)
+                .build();
+        // 생성된 Post 객체를 데이터베이스에 저장
+        postRepository.save(post);
+        // 저장된 Post 객체를 기반으로 PostResponseDto를 생성하여 반환
+        return new PostResponseDto(post);
+    }
+
+    /**
+     * 모든 게시물을 페이지네이션하여 조회하는 메서드
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return 페이지네이션된 게시물 목록
+     */
+    public Page<PostResponseDto> getPosts(int page, int size) {
+        // 페이지네이션 설정 (페이지 번호와 페이지 크기, 정렬 기준)
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        // 설정된 페이지네이션과 정렬 기준으로 게시물 목록 조회
+        Page<Post> posts = postRepository.findAll(pageable);
+        // 조회된 게시물 목록을 PostResponseDto로 변환하여 반환
+        return posts.map(PostResponseDto::new);
+    }
+
+    /**
+     * 게시물을 수정하는 메서드
+     * @param postId 수정할 게시물 ID
+     * @param postRequestDto 게시물 수정 요청 DTO
+     * @param user 인증된 사용자 정보
+     * @return 수정된 게시물 정보
+     */
+    public PostResponseDto updatePost(Long postId, PostRequestDto postRequestDto, User user) {
+        // 게시물 ID로 게시물을 조회하고, 존재하지 않으면 예외 발생
+        Post post = postRepository.findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+
+        // 게시물 작성자와 현재 사용자가 일치하지 않으면 예외 발생
+        if (!post.getUser().equals(user)) {
+            throw new UnauthorizedException("작성자 또는 관리자만 수정할 수 있습니다.");
+        }
+
+        // 카테고리 유효성 검사
+        if (!postRequestDto.isValidCategory()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담 2개의 카테고리 중 하나를 입력해주세요.");
+        }
+
+        // 게시물의 내용을 수정
+        post.setShowName(postRequestDto.getShowName());
+        post.setContent(postRequestDto.getContent());
+        post.setCategory(postRequestDto.getCategory());
+        post.setUpdatedAt(LocalDateTime.now());
+
+        // 수정된 게시물을 데이터베이스에 저장
+        postRepository.save(post);
+        // 수정된 게시물을 기반으로 PostResponseDto를 생성하여 반환
+        return new PostResponseDto(post);
+    }
+
+    /**
+     * 게시물을 삭제하는 메서드
+     * @param postId 삭제할 게시물 ID
+     * @param user 인증된 사용자 정보
+     */
+    public void deletePost(Long postId, User user) {
+        // 게시물 ID로 게시물을 조회하고, 존재하지 않으면 예외 발생
+        Post post = postRepository.findById(postId)
+                .orElseThrow(NotFoundPostException::new);
+
+        // 게시물 작성자와 현재 사용자가 일치하지 않으면 예외 발생
+        if (!post.getUser().equals(user)) {
+            throw new UnauthorizedException("작성자 또는 관리자만 삭제할 수 있습니다.");
+        }
+
+        // 게시물을 데이터베이스에서 삭제
+        postRepository.delete(post);
+    }
 }

--- a/src/main/java/com/sparta/sixhundredbills/timestamp/TimeStamp.java
+++ b/src/main/java/com/sparta/sixhundredbills/timestamp/TimeStamp.java
@@ -1,4 +1,4 @@
-package com.sparta.sixhundredbills;
+package com.sparta.sixhundredbills.timestamp;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/sparta/sixhundredbills/timestamp/TimeStamp.java
+++ b/src/main/java/com/sparta/sixhundredbills/timestamp/TimeStamp.java
@@ -18,19 +18,17 @@ public abstract class TimeStamp {
 
     @CreatedDate
     @Column(updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column
-    @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime modifiedAt;
 
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public void setModifiedAt(LocalDateTime modifiedAt) {
+    public void setUpdatedAt(LocalDateTime modifiedAt) {
         this.modifiedAt = modifiedAt;
     }
 }

--- a/src/main/java/com/sparta/sixhundredbills/util/AnonymousNameGenerator.java
+++ b/src/main/java/com/sparta/sixhundredbills/util/AnonymousNameGenerator.java
@@ -1,0 +1,16 @@
+package com.sparta.sixhundredbills.util;
+
+import java.util.UUID;
+
+/**
+ * UUID 사용 -> 게시물 생성 시 익명 닉네임 생성
+ * UUID는 중복될 가능성이 거의 없는 고유 식별자를 생성하는데 사용
+ */
+public class AnonymousNameGenerator {
+    public static String generate() {
+        return "익명" + UUID.randomUUID().toString().substring(0, 6);
+        //UUID.randomUUID().toString() -> 이 부분은 고유한 UUID를 생성하고 문자열로 변환
+        //substring(0, 6) -> UUID 문자열의 첫 6문자를 추출. 닉네임으로 사용하기 위해 일부만 사용
+        //생성된 익명닉네임 : 익명123456
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=SixhundredBills
+
+# MySQL Database Configuration
+spring.datasource.url=jdbc:mysql://localhost:3306/sixhundreds
+spring.datasource.username=root
+spring.datasource.password=Oplk1107950!
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA and Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
<br/>

## ➕ 제목 : Feat/#3 Make Post registration, delection, retrieval, edit

<br/>

## 🔎 작업 내용

게시물 작성, 조회, 삭제, 수정 기능 구현



익명사용자명 생성 클래스 구현.
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/6270b4e2-9d49-49e3-bb48-b22c91a53b4e)


User 엔티티는 경민님이 구현하신 거 그대로 갖고옴. 

role enum 추가(ADMIN, USER)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/bf50b4b6-b3de-4a55-90aa-a25ffb6ab811)


GlobalExceptionHandler 구현 및 POST에 필요한 exception 구현
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/ff885d53-a06b-4672-913f-5fc1930756c7)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/2bd898e2-6857-4786-b0cb-ce4b0b3e7ca7)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/a78f55a3-7a5a-4b20-bdc4-2717e33db62a)


<br/>

## ➕ 기타 수정 사항

- ADD
    - Post registraion
    - Post delection
    - Post retrieval
    - AnonymousNameGenerator
    - role enum
    - GlobalExceptionHandler
    - InfoNotCorrectedException
    - NotFoundPostException
    - UnauthorizedException

<br/>

## 🔧 앞으로의 과제

- jwt 토큰 구현 완료 시 적용 후 테스트


  <br/>

