### PR TITLE
Fix/#3 - Refactor post-related code and implement JWT token handling

### DIFF
--- a/src/main/java/com/sparta/sixhundredbills/auth/entity/User.java
+++ b/src/main/java/com/sparta/sixhundredbills/auth/entity/User.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @Entity // JPA 엔티티임을 나타내는 어노테이션
 @Getter // Lombok: 모든 필드에 대한 getter 메서드 자동 생성
 @Setter // Lombok: 모든 필드에 대한 setter 메서드 자동 생성
-@Table(name = "sixhundredbills") // 데이터베이스 테이블 이름 지정
+@Table(name = "users") // 데이터베이스 테이블 이름 지정 - ERD에 맞게 users로 수정하였습니다 - 유규리
 @NoArgsConstructor // Lombok: 매개변수 없는 기본 생성자 자동 생성
 public class User extends TimeStamp {
 

--- a/src/main/java/com/sparta/sixhundredbills/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/sixhundredbills/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Enumeration;
@@ -18,6 +19,12 @@ import java.util.Enumeration;
  * ErrorEnum을 한 번만 체크하고, 각 예외를 처리하는 로직을 반복적으로 작성하지 않도록 최적화.
 
  */
+/**
+ * JWT 인증 진입점 클래스.
+ * 인증되지 않은 사용자 요청에 대해 예외를 처리.
+ * ErrorEnum을 한 번만 체크하고, 각 예외를 처리하는 로직을 반복적으로 작성하지 않도록 최적화.
+ */
+@Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 직렬화를 위한 ObjectMapper 객체 => 예외 메시지를 JSON 형식으로 반환하는 데 사용.
@@ -29,28 +36,27 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
      * @param authException 인증 예외 객체
      * @throws IOException IO 예외 발생 시
      * @throws ServletException 서블릿 예외 발생 시
+     * 이부분 수정하였습니다(enum 캐스팅에서 실행에러가 떠서 잘 돌아가도록 수정하였습니다) - 유규리
      */
-
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        // 요청의 속성들(예외 정보)을 열거형으로 가져옴
-        Enumeration<String> exceptionNames = request.getAttributeNames();
+        // 요청 속성에서 ErrorEnum 객체를 직접 가져옴
+        ErrorEnum errorEnum = (ErrorEnum) request.getAttribute("errorEnum");
 
-        // 모든 속성들을 반복 처리
-        while (exceptionNames.hasMoreElements()) {
-            String exception = exceptionNames.nextElement(); // 다음 속성 이름
-            ErrorEnum errorEnum = (ErrorEnum) request.getAttribute(exception); // 속성에서 ErrorEnum 객체를 가져옴
+        // ErrorEnum 객체가 있는 경우
+        if (errorEnum != null) {
+            // 에러 응답 객체 생성
+            FilterExceptionResponse filterExceptionResponse = new FilterExceptionResponse(errorEnum.getStatusCode(), errorEnum.getMessage());
 
-            // ErrorEnum 객체가 있는 경우
-            if (errorEnum != null) {
-                // 에러 응답 객체 생성
-                FilterExceptionResponse filterExceptionResponse = new FilterExceptionResponse(errorEnum.getStatusCode(), errorEnum.getMessage());
-
-                // 응답 설정
-                response.setStatus(errorEnum.getStatusCode()); // 상태 코드 설정
-                response.setCharacterEncoding("UTF-8"); // 응답의 문자 인코딩 설정
-                response.getWriter().write(objectMapper.writeValueAsString(filterExceptionResponse)); // 응답에 에러 메시지 작성
-            }
+            // 응답 설정
+            response.setStatus(errorEnum.getStatusCode()); // 상태 코드 설정
+            response.setCharacterEncoding("UTF-8"); // 응답의 문자 인코딩 설정
+            response.getWriter().write(objectMapper.writeValueAsString(filterExceptionResponse)); // 응답에 에러 메시지 작성
+        } else {
+            // ErrorEnum 객체가 없는 경우 기본 예외 응답 처리
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 기본 상태 코드 설정
+            response.setCharacterEncoding("UTF-8"); // 응답의 문자 인코딩 설정
+            response.getWriter().write(objectMapper.writeValueAsString(new FilterExceptionResponse(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"))); // 기본 에러 메시지 작성
         }
     }
 }

--- a/src/main/java/com/sparta/sixhundredbills/auth/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/sixhundredbills/auth/security/UserDetailsImpl.java
@@ -98,6 +98,15 @@ public class UserDetailsImpl implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+
+    /**
+     * 게시물 및 댓글파트에서 사용자 정보 가져오려면 필수불가결합니다!
+     * 추가하였습니다 - 유규리
+     */
+    public User getUser() {
+        return user;
+    }
 }
 
 

--- a/src/main/java/com/sparta/sixhundredbills/post/controller/PostController.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.sparta.sixhundredbills.post.controller;
 
 
 import com.sparta.sixhundredbills.auth.entity.User;
+import com.sparta.sixhundredbills.auth.security.UserDetailsImpl;
 import com.sparta.sixhundredbills.post.dto.PostRequestDto;
 import com.sparta.sixhundredbills.post.dto.PostResponseDto;
 import com.sparta.sixhundredbills.post.service.PostService;
@@ -12,60 +13,72 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
-@RequestMapping("/post")
+@RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
 
     private final PostService postService;
 
     /**
-     * 게시물을 생성하는 메서드
-     * @param postRequestDto 게시물 생성 요청 DTO
-     * @param user 인증된 사용자 정보
-     * @return 생성된 게시물 정보
+     * 게시물을 생성하는 엔드포인트
+     * @param postRequestDto 게시물 요청 데이터
+     * @param userDetails 인증된 사용자 정보
+     * @return 생성된 게시물의 응답 데이터
      */
+
     @PostMapping
-    public ResponseEntity<PostResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal User user) {
-        PostResponseDto responseDto = postService.createPost(postRequestDto, user);
+    public ResponseEntity<PostResponseDto> createPost(@RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
+        PostResponseDto responseDto = postService.createPost(postRequestDto, userDetails.getUser());
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
     /**
-     * 모든 게시물을 페이지네이션하여 조회하는 메서드
-     * @param page 페이지 번호
-     * @param size 페이지 크기
-     * @return 페이지네이션된 게시물 목록
+     * 게시물을 조회하는 엔드포인트
+     * @param page 조회할 페이지 번호
+     * @return 페이징된 게시물 응답 데이터
      */
     @GetMapping
-    public ResponseEntity<Page<PostResponseDto>> getPosts(@RequestParam int page, @RequestParam int size) {
+    public ResponseEntity<Page<PostResponseDto>> getPosts(@RequestParam int page) {
+        int size = 5;
         Page<PostResponseDto> posts = postService.getPosts(page, size);
         return new ResponseEntity<>(posts, HttpStatus.OK);
     }
 
     /**
-     * 게시물을 수정하는 메서드
+     * 게시물을 수정하는 엔드포인트
      * @param postId 수정할 게시물 ID
-     * @param postRequestDto 게시물 수정 요청 DTO
-     * @param user 인증된 사용자 정보
-     * @return 수정된 게시물 정보
+     * @param postRequestDto 게시물 요청 데이터
+     * @param userDetails 인증된 사용자 정보
+     * @return 수정된 게시물의 응답 데이터
      */
     @PutMapping("/{postId}")
-    public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal User user) {
-        PostResponseDto responseDto = postService.updatePost(postId, postRequestDto, user);
+    public ResponseEntity<PostResponseDto> updatePost(@PathVariable Long postId, @RequestBody PostRequestDto postRequestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+        PostResponseDto responseDto = postService.updatePost(postId, postRequestDto, userDetails.getUser());
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     /**
-     * 게시물을 삭제하는 메서드
+     * 게시물을 삭제하는 엔드포인트
      * @param postId 삭제할 게시물 ID
-     * @param user 인증된 사용자 정보
-     * @return 삭제 결과
+     * @param userDetails 인증된 사용자 정보
+     * @return 응답 상태 코드
      */
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal User user) {
-        postService.deletePost(postId, user);
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+        postService.deletePost(postId, userDetails.getUser());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/dto/PostRequestDto.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/dto/PostRequestDto.java
@@ -8,20 +8,21 @@ import java.util.List;
 
 @Getter
 @Setter
+@Builder
 public class PostRequestDto {
 
     @NotBlank(message = "내용이 비어있습니다.")
-    private String content; // 게시물 내용
-
-    private String showName; // 익명으로 표시될 이름
+    private String content;
 
     @NotBlank(message = "카테고리를 입력해주세요.")
-    private String category; // 게시물 카테고리
+    private String category;
 
-    // 유효한 카테고리 목록
-    private static final List<String> VALID_CATEGORIES = Arrays.asList("일상공유", "고민상담");
+    private static final List<String> VALID_CATEGORIES = Arrays.asList("일상공유", "고민상담", "익명토론");
 
-    // 카테고리 유효성 검사
+    /**
+     * 카테고리가 유효한지 확인하는 메서드
+     * @return 유효한 카테고리인지 여부
+     */
     public boolean isValidCategory() {
         return VALID_CATEGORIES.contains(this.category);
     }

--- a/src/main/java/com/sparta/sixhundredbills/post/dto/PostResponseDto.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/dto/PostResponseDto.java
@@ -8,15 +8,14 @@ import java.time.LocalDateTime;
 
 @Getter
 public class PostResponseDto {
-    private Long id; // 게시물 ID
-    private Long userId; // 작성자 ID
-    private String showName; // 익명으로 표시될 이름
-    private String content; // 게시물 내용
-    private String category; // 게시물 카테고리
-    private LocalDateTime createdAt; // 생성일자
-    private LocalDateTime updatedAt; // 수정일자
+    private Long id;
+    private Long userId;
+    private String showName;
+    private String content;
+    private String category;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    // 모든 필드를 포함하는 생성자
     @Builder
     public PostResponseDto(Long id, Long userId, String showName, String content, String category, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
@@ -28,7 +27,10 @@ public class PostResponseDto {
         this.updatedAt = updatedAt;
     }
 
-    // Post 엔티티를 기반으로 PostResponseDto를 생성하는 생성자
+    /**
+     * Post 엔티티를 이용해 PostResponseDto 객체를 생성하는 생성자
+     * @param post Post 엔티티
+     */
     public PostResponseDto(Post post) {
         this.id = post.getId();
         this.userId = post.getUser().getId();

--- a/src/main/java/com/sparta/sixhundredbills/post/entity/Post.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/entity/Post.java
@@ -16,43 +16,24 @@ public class Post extends TimeStamp {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id; // 게시물 ID
+    private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user; // 작성자
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    private String showName; // 익명으로 표시될 이름
-    private String content; // 게시물 내용
-    private String category; // 게시물 카테고리
-    private int likeCount; // 좋아요 수
+    private String showName;
+    private String content;
+    private String category;
+    private int likeCount;
 
     @Builder
-    public Post(User user, String showName, String content, String category, int likeCount) {
+    public Post(Long id, User user, String showName, String content, String category, int likeCount) {
+        this.id = id;
         this.user = user;
         this.showName = showName;
         this.content = content;
         this.category = category;
         this.likeCount = likeCount;
-    }
-
-    // 게시물 내용 수정
-    public void setContent(String content) {
-        this.content = content;
-    }
-
-    // 작성자 정보 수정
-    public void setUser(User user) {
-        this.user = user;
-    }
-
-    // 작성자 이름 수정
-    public void setShowName(String showName) {
-        this.showName = showName;
-    }
-
-    // 카테고리 수정
-    public void setCategory(String category) {
-        this.category = category;
     }
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/repository/PostRepository.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/repository/PostRepository.java
@@ -6,7 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * 모든 게시물을 페이지네이션하여 조회
+     * @param pageable 페이지 정보
+     * @return 페이지네이션된 게시물 목록
+     */
     Page<Post> findAll(Pageable pageable); // 모든 게시물을 페이지네이션하여 조회
 }

--- a/src/main/java/com/sparta/sixhundredbills/post/service/PostService.java
+++ b/src/main/java/com/sparta/sixhundredbills/post/service/PostService.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -25,100 +24,83 @@ public class PostService {
 
     private final PostRepository postRepository;
 
+
     /**
      * 게시물을 생성하는 메서드
-     * @param postRequestDto 게시물 생성 요청 DTO
-     * @param user 작성자 정보
-     * @return 생성된 게시물 정보
+     * @param postRequestDto 게시물 요청 데이터
+     * @param user 게시물 작성자
+     * @return 생성된 게시물의 응답 데이터
      */
     public PostResponseDto createPost(PostRequestDto postRequestDto, User user) {
-        // 카테고리 유효성 검사
         if (!postRequestDto.isValidCategory()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담 2개의 카테고리 중 하나를 입력해주세요.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담, 익명토론 중 하나를 입력해주세요.");
         }
 
-        // 익명 닉네임 생성
         String anonymousName = AnonymousNameGenerator.generate();
 
-        // Post 객체를 빌더 패턴을 사용하여 생성
         Post post = Post.builder()
                 .user(user)
-                .showName(anonymousName) // 익명 닉네임 설정
+                .showName(anonymousName)
                 .content(postRequestDto.getContent())
                 .category(postRequestDto.getCategory())
                 .likeCount(0)
                 .build();
-        // 생성된 Post 객체를 데이터베이스에 저장
+
         postRepository.save(post);
-        // 저장된 Post 객체를 기반으로 PostResponseDto를 생성하여 반환
         return new PostResponseDto(post);
     }
 
     /**
-     * 모든 게시물을 페이지네이션하여 조회하는 메서드
-     * @param page 페이지 번호
-     * @param size 페이지 크기
+     * 게시물을 페이지네이션하여 조회하는 메서드
+     * @param page 조회할 페이지 번호
+     * @param size 페이지 당 항목 수(5개로 고정)
      * @return 페이지네이션된 게시물 목록
      */
     public Page<PostResponseDto> getPosts(int page, int size) {
-        // 페이지네이션 설정 (페이지 번호와 페이지 크기, 정렬 기준)
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        // 설정된 페이지네이션과 정렬 기준으로 게시물 목록 조회
         Page<Post> posts = postRepository.findAll(pageable);
-        // 조회된 게시물 목록을 PostResponseDto로 변환하여 반환
         return posts.map(PostResponseDto::new);
     }
 
     /**
      * 게시물을 수정하는 메서드
      * @param postId 수정할 게시물 ID
-     * @param postRequestDto 게시물 수정 요청 DTO
-     * @param user 인증된 사용자 정보
-     * @return 수정된 게시물 정보
+     * @param postRequestDto 게시물 요청 데이터
+     * @param user 게시물 작성자
+     * @return 수정된 게시물의 응답 데이터
      */
     public PostResponseDto updatePost(Long postId, PostRequestDto postRequestDto, User user) {
-        // 게시물 ID로 게시물을 조회하고, 존재하지 않으면 예외 발생
         Post post = postRepository.findById(postId)
                 .orElseThrow(NotFoundPostException::new);
 
-        // 게시물 작성자와 현재 사용자가 일치하지 않으면 예외 발생
-        if (!post.getUser().equals(user)) {
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new UnauthorizedException("작성자 또는 관리자만 수정할 수 있습니다.");
         }
 
-        // 카테고리 유효성 검사
         if (!postRequestDto.isValidCategory()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담 2개의 카테고리 중 하나를 입력해주세요.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "카테고리에 일상공유, 고민상담, 익명토론 중 하나를 입력해주세요.");
         }
 
-        // 게시물의 내용을 수정
-        post.setShowName(postRequestDto.getShowName());
         post.setContent(postRequestDto.getContent());
         post.setCategory(postRequestDto.getCategory());
-        post.setUpdatedAt(LocalDateTime.now());
 
-        // 수정된 게시물을 데이터베이스에 저장
         postRepository.save(post);
-        // 수정된 게시물을 기반으로 PostResponseDto를 생성하여 반환
         return new PostResponseDto(post);
     }
 
     /**
      * 게시물을 삭제하는 메서드
      * @param postId 삭제할 게시물 ID
-     * @param user 인증된 사용자 정보
+     * @param user 게시물 작성자
      */
     public void deletePost(Long postId, User user) {
-        // 게시물 ID로 게시물을 조회하고, 존재하지 않으면 예외 발생
         Post post = postRepository.findById(postId)
                 .orElseThrow(NotFoundPostException::new);
 
-        // 게시물 작성자와 현재 사용자가 일치하지 않으면 예외 발생
-        if (!post.getUser().equals(user)) {
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new UnauthorizedException("작성자 또는 관리자만 삭제할 수 있습니다.");
         }
 
-        // 게시물을 데이터베이스에서 삭제
         postRepository.delete(post);
     }
 }


### PR DESCRIPTION
<br/>

## 🔎  제목 :  Fix/#3 Refactor post-related code and implement JWT token handling

<br/>

## 🔎 작업 내용

- 게시물 관련 코드에 jwt 토큰 적용(@AuthenticationPrincipal을 통해 JWT 토큰 인증을 처리하도록 PostController, PostService 리팩토링)

- posts 관련 클래스들 인스턴스 생성 방식 builder로 통일(팀 내 코드 컨벤션 규칙)

- 페이지네이션 무조건 5로 적용
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/312a4be7-4a71-4f70-a85e-9978f7ea28d5)

- 사용자와 토큰을 비교하는 부분 중, post.getUser().equals(user)로 비교 시 디버깅했을 때 똑같이 나오지만, 실제로 계속 예외에 걸려 테스트가 실패하는 경우가 있었음. getId()를 추가함으로써 문제 해결
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/b78762ad-663e-4ac7-8513-65aa76118863)

- UserDetailsImpl에 getUser 추가
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/ec945f17-4778-45da-bb54-d8156c77ceb5)

- JwtAuthenticationEntryPoint에서 enum 캐스팅 문제로 실행오류 발생 -> commence 메소드 수정
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/25460f94-0b3a-4c86-9162-ebafaf50bcee)

- User entity에서 테이블 이름 'sixhundredsbills'에서 'users'로 수정(ERD 다이어그램 반영)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/aee9df30-bd60-4f05-846b-d030e9e20364)

- SecurityConfig에서 필터 중 빠진 부분이 있어 예외처리가 제대로 안되는 상황 발생(무조건 401로 예외가 뜸)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/1c76db18-b3a0-4fcd-a0f4-44fab338bf0b)


postman 실행 결과

1. 게시물 작성
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/0bed8ba4-c045-494e-87b2-41193e469e4f)


2. 게시물 조회
  
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/7aba108f-c043-4825-ad53-eebfb12088cd)
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/3d186e5f-b9da-4fc1-98d8-a9a02efd4fc4)


3. 게시물 수정
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/5051c326-a221-4667-82bd-e9103a1cc867)


4. 게시물 삭제
![image](https://github.com/SixhundredBills/SixhundredBills/assets/97787677/c8ceebe5-8dba-436b-94d9-036ab6fbf8a9)


<br/>

## 🔎  기타 수정 사항

-jwt 관련 코드 중 실행에 방해가 되거나 제대로 작동하지 않는 부분들 수정
- @AuthenticationPrincipal을 통해 JWT 토큰 인증을 처리하도록 PostController 리팩토링
- 코드 컨벤션 한 것과 같이, 생성자 패턴을 builder 패턴으로 바꿈.
- getPosts 메서드에서 일관된 페이지네이션을 위해 @RequestParam 기본값(5) 추가
- PostService에서 createPost, updatePost, deletePost 메서드에 적절한 jwt 인증 체크 구현
- 페이지네이션 지원을 위한 PostRepository 업데이트
- jwt 관련 코드 중 실행에 방해가 되거나 제대로 작동하지 않는 부분들 수정


FIX
    - JwtAuthenticationEntryPoint.java
    - Post.java
    - PostController.java
    - PostRepository.java
    - PostRequestDto.java
    - PostResponseDto.java
    - PostService.java
    - SecurityConfig.java
    - User.java
    - UserDetailsImpl.java

<br/>

## 🔎   앞으로의 과제

- 예외처리(예외 코드 및 메세지 맞게 뜨게 구현)

  <br/>
